### PR TITLE
use /var/log for logging if it exists as a dir

### DIFF
--- a/FreeTAKServer/controllers/configuration/LoggingConstants.py
+++ b/FreeTAKServer/controllers/configuration/LoggingConstants.py
@@ -3,12 +3,19 @@ from pathlib import PurePath
 class LoggingConstants:
     def __init__(self):
         #main logging config
-        self.CURRENTPATH = os.path.dirname(os.path.realpath(__file__))
-        self.CURRENTPATH = PurePath(self.CURRENTPATH)
-        self.PARENTPATH = str(self.CURRENTPATH.parents[0])
+        # if on a unix type system with /var/log put the logs there
+        if os.path.isdir('/var/log'):
+            self.PARENTPATH = '/var'
+            self.LOGDIRECTORY = 'log'
+        else:
+            # determine the log path the old way under the execution path
+            self.CURRENTPATH = os.path.dirname(os.path.realpath(__file__))
+            self.CURRENTPATH = PurePath(self.CURRENTPATH)
+            self.PARENTPATH = str(self.CURRENTPATH.parents[0])
+            self.LOGDIRECTORY = 'logs'
+
         self.LOGFORMAT = '%(levelname)s : %(asctime)s : %(filename)s:%(lineno)d : %(message)s'
         self.LOGNAME = 'FTS'
-        self.LOGDIRECTORY = 'logs'
         self.ERRORLOG = str(PurePath(self.PARENTPATH, f"{self.LOGDIRECTORY}/{self.LOGNAME}_error.log"))
         self.DEBUGLOG = str(PurePath(self.PARENTPATH, f"{self.LOGDIRECTORY}/{self.LOGNAME}_debug.log"))
         self.INFOLOG = str(PurePath(self.PARENTPATH, f"{self.LOGDIRECTORY}/{self.LOGNAME}_info.log"))


### PR DESCRIPTION
By default FTS on linux/unix systems is putting log files under the code dirs, typically /usr/local/lib for pip installs. 

Proper unix behavior is to have dynamic files (and especially log files) in /var/log.

This change sets the log dir to /var/log if it exists as a directory. Otherwise uses the prior approach of a logs dir under the controllers. 

As before, both methods fail if FTS is executed as other than root (assuming the normal pip install in /usr/local/lib). Future enhancement might be to have it check for write perms, and use dir local to the user if needed. 