### PR TITLE
Fix wizard

### DIFF
--- a/FreeTAKServer/controllers/configuration/MainConfig.py
+++ b/FreeTAKServer/controllers/configuration/MainConfig.py
@@ -11,7 +11,7 @@ class MainConfig:
     """
 
     # the version information of the server (recommended to leave as default)
-    version = 'FreeTAKServer-1.9.9.5.5 Public'
+    version = 'FreeTAKServer-0.1.9.9.5.5 Public'
     #
     yaml_path = str(os.environ.get('FTS_CONFIG_PATH', '/opt/FTSConfig.yaml'))
 

--- a/FreeTAKServer/controllers/configuration/MainConfig.py
+++ b/FreeTAKServer/controllers/configuration/MainConfig.py
@@ -11,7 +11,7 @@ class MainConfig:
     """
 
     # the version information of the server (recommended to leave as default)
-    version = 'FreeTAKServer-1.9.9.5 Public'
+    version = 'FreeTAKServer-1.9.9.5.5 Public'
     #
     yaml_path = str(os.environ.get('FTS_CONFIG_PATH', '/opt/FTSConfig.yaml'))
 

--- a/FreeTAKServer/controllers/configuration/MainConfig.py
+++ b/FreeTAKServer/controllers/configuration/MainConfig.py
@@ -306,4 +306,4 @@ class MainConfig:
     # location to backup client packages
     clientPackages = str(Path(fr'{MainPath}/certs/ClientPackages'))
 
-    first_start = False
+    first_start = True

--- a/FreeTAKServer/controllers/configuration/MainConfig.py
+++ b/FreeTAKServer/controllers/configuration/MainConfig.py
@@ -11,7 +11,7 @@ class MainConfig:
     """
 
     # the version information of the server (recommended to leave as default)
-    version = 'FreeTAKServer-0.1.9.9.5.5 Public'
+    version = 'FreeTAKServer-1.9.9.5.5 Public'
     #
     yaml_path = str(os.environ.get('FTS_CONFIG_PATH', '/opt/FTSConfig.yaml'))
 

--- a/FreeTAKServer/controllers/configuration/MainConfig.py
+++ b/FreeTAKServer/controllers/configuration/MainConfig.py
@@ -11,7 +11,8 @@ class MainConfig:
     """
 
     # the version information of the server (recommended to leave as default)
-    version = 'FreeTAKServer-1.9.9.5.5 Public'
+    version_spec = '1.9.9.5.5'
+    version = f'FreeTAKServer-{version_spec} Public'
     #
     yaml_path = str(os.environ.get('FTS_CONFIG_PATH', '/opt/FTSConfig.yaml'))
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ setup(
     name='FreeTAKServer',
     packages=find_packages(include = ['FreeTAKServer', 'FreeTAKServer.*']),
     version='0.1.9.9.5.5',
-
     license='EPL-2.0',
     description='An open source server for the TAK family of applications.',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md')) as f:
 setup(
     name='FreeTAKServer',
     packages=find_packages(include = ['FreeTAKServer', 'FreeTAKServer.*']),
-    version='1.9.9.5',
+    version='0.1.9.9.5.5',
 
     license='EPL-2.0',
     description='An open source server for the TAK family of applications.',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import find_packages, setup
 from os import path
+from FreeTAKServer.controllers.configuration.MainConfig import MainConfig
 
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md')) as f:
@@ -7,7 +8,7 @@ with open(path.join(this_directory, 'README.md')) as f:
 setup(
     name='FreeTAKServer',
     packages=find_packages(include = ['FreeTAKServer', 'FreeTAKServer.*']),
-    version='0.1.9.9.5.5',
+    version=MainConfig.version_spec,
     license='EPL-2.0',
     description='An open source server for the TAK family of applications.',
     long_description=long_description,


### PR DESCRIPTION
This PR updates the MainConfig to enable setup wizard by default on pip installation. Updates to setup.py to utilize version spec set in MainConfig.py