### PR TITLE
Revert "Pull release version from MainConfig"

### DIFF
--- a/FreeTAKServer/controllers/configuration/MainConfig.py
+++ b/FreeTAKServer/controllers/configuration/MainConfig.py
@@ -11,8 +11,7 @@ class MainConfig:
     """
 
     # the version information of the server (recommended to leave as default)
-    version_spec = '1.9.9.5.5'
-    version = f'FreeTAKServer-{version_spec} Public'
+    version = 'FreeTAKServer-1.9.9.5.5 Public'
     #
     yaml_path = str(os.environ.get('FTS_CONFIG_PATH', '/opt/FTSConfig.yaml'))
 

--- a/FreeTAKServer/controllers/configuration/MainConfig.py
+++ b/FreeTAKServer/controllers/configuration/MainConfig.py
@@ -11,7 +11,7 @@ class MainConfig:
     """
 
     # the version information of the server (recommended to leave as default)
-    version = 'FreeTAKServer-1.9.9.5.5 Public'
+    version = 'FreeTAKServer-1.9.9.6 Public'
     #
     yaml_path = str(os.environ.get('FTS_CONFIG_PATH', '/opt/FTSConfig.yaml'))
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md')) as f:
 setup(
     name='FreeTAKServer',
     packages=find_packages(include = ['FreeTAKServer', 'FreeTAKServer.*']),
-    version='0.1.9.9.5.5',
+    version='1.9.9.5.5',
     license='EPL-2.0',
     description='An open source server for the TAK family of applications.',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(path.join(this_directory, 'README.md')) as f:
 setup(
     name='FreeTAKServer',
     packages=find_packages(include = ['FreeTAKServer', 'FreeTAKServer.*']),
-    version='1.9.9.5.5',
+    version='1.9.9.6',
     license='EPL-2.0',
     description='An open source server for the TAK family of applications.',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import find_packages, setup
 from os import path
-from FreeTAKServer.controllers.configuration.MainConfig import MainConfig
 
 this_directory = path.abspath(path.dirname(__file__))
 with open(path.join(this_directory, 'README.md')) as f:
@@ -8,7 +7,7 @@ with open(path.join(this_directory, 'README.md')) as f:
 setup(
     name='FreeTAKServer',
     packages=find_packages(include = ['FreeTAKServer', 'FreeTAKServer.*']),
-    version=MainConfig.version_spec,
+    version='0.1.9.9.5.5',
     license='EPL-2.0',
     description='An open source server for the TAK family of applications.',
     long_description=long_description,


### PR DESCRIPTION
This reverts commit 9f47c4735ca35b6c077d8831d47188d415c4f34c.

Pulling the version from MainConfig introduces an issue with build step where pyyaml is required before setup.py can run. In favor of updating setup.cfg to account for this, this commit will be reverted.