### PR TITLE
Rework MainConfig to simplify logic and handle 12 factor method

### DIFF
--- a/FreeTAKServer/controllers/configuration/MainConfig.py
+++ b/FreeTAKServer/controllers/configuration/MainConfig.py
@@ -17,7 +17,6 @@ class MainConfig:
     yaml_path = str(os.environ.get('FTS_CONFIG_PATH', '/opt/FTSConfig.yaml'))
     python_version = 'python3.8'
     userpath = '/usr/local/lib/'
-    first_start = True
 
     try:
         import socket
@@ -206,3 +205,5 @@ class MainConfig:
     password = os.environ.get("FTS_CLIENT_CERT_PASSWORD", password)
     websocketkey = os.environ.get("FTS_WEBSOCKET_KEY", websocketkey)
     CRLFile = os.environ.get("FTS_CRLDIR", CRLFile)
+
+    first_start = True

--- a/FreeTAKServer/controllers/configuration/MainConfig.py
+++ b/FreeTAKServer/controllers/configuration/MainConfig.py
@@ -2,7 +2,7 @@ import os
 import yaml
 currentPath = os.path.dirname(os.path.abspath(__file__))
 from pathlib import Path
-
+from uuid import uuid4
 
 class MainConfig:
     """
@@ -12,12 +12,11 @@ class MainConfig:
 
     # the version information of the server (recommended to leave as default)
     version = 'FreeTAKServer-1.9.9.6 Public'
-    #
+
     yaml_path = str(os.environ.get('FTS_CONFIG_PATH', '/opt/FTSConfig.yaml'))
-
     python_version = 'python3.8'
-
     userpath = '/usr/local/lib/'
+    first_start = True
 
     try:
         import socket
@@ -28,266 +27,26 @@ class MainConfig:
     except:
         ip = "0.0.0.0"
 
-    if not os.path.exists(yaml_path):
+    ## The following are *all* the attributes supported by this class
+    ## and their default values
 
-        SecretKey = str(os.environ.get('FTS_SECRET_KEY', 'vnkdjnfjknfl1232#'))
+    ## Network settings ##
+    # Client ports
+    CoTServicePort = 8087
+    SSLCoTServicePort = 8089
 
-        OptimizeAPI = True
+    # this needs to be changed for private data packages to work
+    DataPackageServiceDefaultIP = ip
 
-        DataReceptionBuffer = int(os.environ.get('FTS_DATA_RECEPTION_BUFFER', 1024))
+    # User Connection package IP needs to be set to the IP which is used when creating the connection in your tak device
+    UserConnectionIP = ip
 
-        MaxReceptionTime = int(os.environ.get('FTS_MAX_RECEPTION_TIME', 4))
+    # API IP and port
+    APIIP = '0.0.0.0'
+    APIPort = 19023
 
-        MainLoopDelay = int(os.environ.get('FTS_MAINLOOP_DELAY', 100))
-
-        # this is the port to which clients will connect
-        CoTServicePort = int(os.environ.get('FTS_COT_PORT', 8087))
-
-        SSLCoTServicePort = int(os.environ.get('FTS_SSLCOT_PORT', 8089))
-
-        # this needs to be changed for private data packages to work
-        DataPackageServiceDefaultIP = str(os.environ.get('FTS_DP_ADDRESS', ip))
-
-        # User Connection package IP needs to be set to the IP which is used when creating the connection in your tak device
-        UserConnectionIP = str(os.environ.get('FTS_USER_ADDRESS', ip))
-
-        # api port
-        APIPort = os.environ.get('FTS_API_PORT', 19023)
-
-        # Federation port
-        FederationPort = os.environ.get('FTS_FED_PORT', 9000)
-
-        # api IP
-        APIIP = os.environ.get('FTS_API_ADDRESS', '0.0.0.0')
-
-        # whether or not to save CoT's to the DB
-        SaveCoTToDB = bool(os.environ.get('FTS_COT_TO_DB', True))
-
-        # this should be set before startup
-        DBFilePath = str(os.environ.get('FTS_DB_PATH', r'/opt/FTSDataBase.db'))
-
-        MainPath = str(os.environ.get("FTS_MAINPATH", Path(fr'{userpath}{python_version}/dist-packages/FreeTAKServer')))
-
-        certsPath = str(os.environ.get('FTS_CERTS_PATH', fr'{MainPath}/certs'))
-
-        ExCheckMainPath = str(os.environ.get('FTS_EXCHECK_PATH', Path(fr'{MainPath}/ExCheck')))
-
-        ExCheckFilePath = str(os.environ.get('FTS_EXCHECK_TEMPLATE_PATH', Path(fr'{MainPath}/ExCheck/template')))
-
-        ExCheckChecklistFilePath = str(
-            os.environ.get("FTS_EXCHECK_CHECKLIST_PATH", Path(fr'{MainPath}/ExCheck/checklist')))
-
-        DataPackageFilePath = str(
-            os.environ.get("FTS_DATAPACKAGE_PATH", Path(fr'{MainPath}/FreeTAKServerDataPackageFolder')))
-
-        LogFilePath = str(os.environ.get("FTS_LOGFILE_PATH", Path(fr"{MainPath}/Logs")))
-
-        federationKeyPassword = str(os.environ.get('FTS_FED_PASSWORD', 'defaultpass'))
-
-        keyDir = str(os.environ.get("FTS_SERVER_KEYDIR", Path(fr'{certsPath}/server.key')))
-
-        pemDir = str(os.environ.get("FTS_SERVER_PEMDIR", Path(fr'{certsPath}/server.pem')))  # or crt
-
-        testPem = str(os.environ.get("FTS_TESTCLIENT_PEMDIR", pemDir))
-
-        testKey = str(os.environ.get("FTS_TESTCLIENT_KEYDIR", keyDir))
-
-        unencryptedKey = str(os.environ.get("FTS_UNENCRYPTED_KEYDIR", Path(fr'{certsPath}/server.key.unencrypted')))
-
-        p12Dir = str(os.environ.get("FTS_SERVER_P12DIR", Path(fr'{certsPath}/server.p12')))
-
-        CA = str(os.environ.get("FTS_CADIR", Path(fr'{certsPath}/ca.pem')))
-
-        CAkey = str(os.environ.get("FTS_CAKEYDIR", Path(fr'{certsPath}/ca.key')))
-
-        federationCert = str(os.environ.get("FTS_FEDERATION_CERTDIR", Path(fr'{certsPath}/server.pem')))
-
-        federationKey = str(os.environ.get("FTS_FEDERATION_KEYDIR", Path(fr'{certsPath}/server.key')))
-
-        federationKeyPassword = str(os.environ.get("FTS_FEDERATION_KEYPASS", 'defaultpass'))
-
-        password = str(os.environ.get('FTS_CLIENT_CERT_PASSWORD', 'supersecret'))
-
-        websocketkey = str(os.environ.get('FTS_WEBSOCKET_KEY', "YourWebsocketKey"))
-
-        CRLFile = str(os.environ.get('FTS_CRLDIR', fr"{certsPath}/FTS_CRL.json"))
-
-        # set to None if you don't want a message sent
-        ConnectionMessage = f'Welcome to FreeTAKServer {version}. The Parrot is not dead. It’s just resting'
-
-        DataBaseType = str("SQLite")
-
-    else:
-        content = open(yaml_path).read()
-        yamlConfig = yaml.safe_load(content)
-
-        # number of milliseconds to wait between each iteration of main loop
-        # decreasing will increase CPU usage and server performance
-        # increasing will decrease CPU usage and server performance
-        if yamlConfig.get("System"):
-            MainLoopDelay = int(os.environ.get('FTS_MAINLOOP_DELAY', yamlConfig["System"].get("FTS_MAINLOOP_DELAY", 1)))
-            # set to None if you don't want a message sent
-            ConnectionMessage = str(os.environ.get("FTS_CONNECTION_MESSAGE", yamlConfig["System"].get("FTS_CONNECTION_MESSAGE", f'Welcome to FreeTAKServer {version}. The Parrot is not dead. It’s just resting')))
-            DataBaseType = str(os.environ.get("FTS_DATABASE_TYPE", yamlConfig["System"].get("FTS_DATABASE_TYPE", "SQLite")))
-            OptimizeAPI = bool(os.environ.get("FTS_OPTIMIZE_API", yamlConfig["System"].get("FTS_OPTIMIZE_API", True)))
-            SecretKey = str(os.environ.get('FTS_SECRET_KEY', yamlConfig["System"].get("FTS_SECRET_KEY", 'vnkdjnfjknfl1232#')))
-            DataReceptionBuffer = int(os.environ.get('FTS_DATA_RECEPTION_BUFFER', yamlConfig["System"].get("FTS_DATA_RECEPTION_BUFFER", 1024)))
-            MaxReceptionTime = int(os.environ.get('FTS_MAX_RECEPTION_TIME', yamlConfig["System"].get("FTS_MAX_RECEPTION_TIME", 4)))
-
-        else:
-            MainLoopDelay = int(os.environ.get('FTS_MAINLOOP_DELAY',  1))
-            ConnectionMessage = str(os.environ.get("FTS_CONNECTION_MESSAGE", f'Welcome to FreeTAKServer {version}. The Parrot is not dead. It’s just resting'))
-            DataBaseType = str(os.environ.get("FTS_DATABASE_TYPE", "SQLite"))
-            OptimizeAPI = bool(os.environ.get("FTS_OPTIMIZE_API", True))
-
-        if yamlConfig.get("Addresses"):
-            # this is the port to which clients will connect
-            CoTServicePort = int(os.environ.get('FTS_COT_PORT', yamlConfig["Addresses"].get('FTS_COT_PORT', 8087)))
-
-            SSLCoTServicePort = int(os.environ.get('FTS_SSLCOT_PORT', yamlConfig["Addresses"].get('FTS_SSLCOT_PORT', 8089)))
-
-            # this needs to be changed for private data packages to work
-            DataPackageServiceDefaultIP = str(os.environ.get('FTS_DP_ADDRESS', yamlConfig["Addresses"].get('FTS_DP_ADDRESS', ip)))
-
-            # User Connection package IP needs to be set to the IP which is used when creating the connection in your tak device
-            UserConnectionIP = str(os.environ.get('FTS_USER_ADDRESS', yamlConfig["Addresses"].get("FTS_USER_ADDRESS", ip)))
-
-            # api port
-            APIPort = int(os.environ.get('FTS_API_PORT', yamlConfig["Addresses"].get("FTS_API_PORT", 19023)))
-
-            # Federation port
-            FederationPort = int(os.environ.get('FTS_FED_PORT', yamlConfig["Addresses"].get("FTS_FED_PORT", 9000)))
-
-            # api IP
-            APIIP = str(os.environ.get('FTS_API_ADDRESS', yamlConfig["Addresses"].get("FTS_API_ADDRESS", "0.0.0.0")))
-        else:
-
-            # this is the port to which clients will connect
-            CoTServicePort = int(os.environ.get('FTS_COT_PORT', 8087))
-
-            SSLCoTServicePort = int(os.environ.get('FTS_SSLCOT_PORT', 8089))
-
-            # this needs to be changed for private data packages to work
-            DataPackageServiceDefaultIP = str(os.environ.get('FTS_DP_ADDRESS', "0.0.0.0"))
-
-            # User Connection package IP needs to be set to the IP which is used when creating the connection in your tak device
-            UserConnectionIP = str(os.environ.get('FTS_USER_ADDRESS', "0.0.0.0"))
-
-            # api port
-            APIPort = os.environ.get('FTS_API_PORT', 19023)
-
-            # Federation port
-            FederationPort = os.environ.get('FTS_FED_PORT', 9000)
-
-            # api IP
-            APIIP = os.environ.get('FTS_API_ADDRESS', '0.0.0.0')
-
-        if yamlConfig.get("FileSystem"):
-
-            DBFilePath = str(os.environ.get('FTS_DB_PATH', yamlConfig["FileSystem"].get("FTS_DB_PATH", "/opt/FreeTAKServer.db")))
-
-            # whether or not to save CoT's to the DB
-            SaveCoTToDB = bool(os.environ.get('FTS_COT_TO_DB', yamlConfig["FileSystem"].get("FTS_COT_TO_DB")))
-
-            MainPath = str(os.environ.get("FTS_MAINPATH", yamlConfig["FileSystem"].get("FTS_MAINPATH", Path(fr'{userpath}{python_version}/dist-packages/FreeTAKServer'))))
-
-            certsPath = str(os.environ.get('FTS_CERTS_PATH', yamlConfig["FileSystem"].get("FTS_CERTS_PATH", fr'{MainPath}/certs')))
-
-            ExCheckMainPath = str(os.environ.get('FTS_EXCHECK_PATH', yamlConfig["FileSystem"].get("FTS_EXCHECK_PATH",Path(fr'{MainPath}/ExCheck'))))
-
-            ExCheckFilePath = str(os.environ.get('FTS_EXCHECK_TEMPLATE_PATH', yamlConfig["FileSystem"].get("FTS_EXCHECK_TEMPLATE_PATH", Path(fr'{MainPath}/ExCheck/template'))))
-
-            ExCheckChecklistFilePath = str(os.environ.get("FTS_EXCHECK_CHECKLIST_PATH", yamlConfig["FileSystem"].get("FTS_EXCHECK_CHECKLIST_PATH", Path(fr'{MainPath}/ExCheck/checklist'))))
-
-            DataPackageFilePath = str(os.environ.get("FTS_DATAPACKAGE_PATH", yamlConfig["FileSystem"].get("FTS_DATAPACKAGE_PATH", Path(fr'{MainPath}/FreeTAKServerDataPackageFolder'))))
-
-            LogFilePath = str(os.environ.get("FTS_LOGFILE_PATH", yamlConfig["FileSystem"].get("FTS_LOGFILE_PATH", Path(fr"{MainPath}/Logs"))))
-
-        else:
-            # whether or not to save CoT's to the DB
-            SaveCoTToDB = bool(os.environ.get('FTS_COT_TO_DB', True))
-
-            # this should be set before startup
-            DBFilePath = str(os.environ.get('FTS_DB_PATH', r'/root/FTSDataBase.db'))
-
-            MainPath = str(
-                os.environ.get("FTS_MAINPATH", Path(fr'{userpath}{python_version}/dist-packages/FreeTAKServer')))
-
-            certsPath = str(os.environ.get('FTS_CERTS_PATH', fr'{MainPath}/certs'))
-
-            ExCheckMainPath = str(os.environ.get('FTS_EXCHECK_PATH', Path(fr'{MainPath}/ExCheck')))
-
-            ExCheckFilePath = str(os.environ.get('FTS_EXCHECK_TEMPLATE_PATH', Path(fr'{MainPath}/ExCheck/template')))
-
-            ExCheckChecklistFilePath = str(
-                os.environ.get("FTS_EXCHECK_CHECKLIST_PATH", Path(fr'{MainPath}/ExCheck/checklist')))
-
-            DataPackageFilePath = str(
-                os.environ.get("FTS_DATAPACKAGE_PATH", Path(fr'{MainPath}/FreeTAKServerDataPackageFolder')))
-
-            LogFilePath = str(os.environ.get("FTS_LOGFILE_PATH", Path(fr"{MainPath}/Logs")))
-
-
-        if yamlConfig.get("Certs"):
-            keyDir = str(os.environ.get("FTS_SERVER_KEYDIR", yamlConfig["Certs"].get("FTS_SERVER_KEYDIR", Path(fr'{certsPath}/server.key'))))
-
-            pemDir = str(os.environ.get("FTS_SERVER_PEMDIR",yamlConfig["Certs"].get("FTS_SERVER_PEMDIR", Path(fr'{certsPath}/server.pem')))) # or crt
-
-            testPem = str(os.environ.get("FTS_TESTCLIENT_PEMDIR",yamlConfig["Certs"].get("FTS_TESTCLIENT_PEMDIR", fr'{certsPath}/Client.pem')))
-
-            testKey = str(os.environ.get("FTS_TESTCLIENT_KEYDIR",yamlConfig["Certs"].get("FTS_TESTCLIENT_KEYDIR", fr'{certsPath}/Client.key')))
-
-            unencryptedKey = str(os.environ.get("FTS_UNENCRYPTED_KEYDIR", yamlConfig["Certs"].get("FTS_UNENCRYPTED_KEYDIR", Path(fr'{certsPath}/server.key.unencrypted'))))
-
-            p12Dir = str(os.environ.get("FTS_SERVER_P12DIR", yamlConfig["Certs"].get("FTS_SERVER_P12DIR", Path(fr'{certsPath}/server.p12'))))
-
-            CA = str(os.environ.get("FTS_CADIR", yamlConfig["Certs"].get("FTS_CADIR",Path(fr'{certsPath}/ca.pem'))))
-
-            CAkey = str(os.environ.get("FTS_CAKEYDIR", yamlConfig["Certs"].get("FTS_CAKEYDIR",Path(fr'{certsPath}/ca.key'))))
-
-            federationCert = str(os.environ.get("FTS_FEDERATION_CERTDIR", yamlConfig["Certs"].get("FTS_FEDERATION_CERTDIR", Path(fr'{certsPath}/server.pem'))))
-
-            federationKey = str(os.environ.get("FTS_FEDERATION_KEYDIR", yamlConfig["Certs"].get("FTS_FEDERATION_KEYDIR", Path(fr'{certsPath}/server.key'))))
-
-            federationKeyPassword = str(os.environ.get("FTS_FEDERATION_KEYPASS", yamlConfig["Certs"].get("FTS_FEDERATION_KEYPASS", None)))
-
-            password = str(os.environ.get('FTS_CLIENT_CERT_PASSWORD', yamlConfig["Certs"].get("FTS_CLIENT_CERT_PASSWORD", 'supersecret')))
-
-            websocketkey = str(os.environ.get('FTS_WEBSOCKET_KEY', yamlConfig["Certs"].get("FTS_WEBSOCKET_KEY", "YourWebsocketKey")))
-
-            CRLFile = str(os.environ.get('FTS_CRLDIR', yamlConfig["Certs"].get("FTS_CRLDIR", fr"{certsPath}/FTS_CRL.json")))
-        else:
-            federationKeyPassword = str(os.environ.get('FTS_FED_PASSWORD', 'defaultpass'))
-
-            keyDir = str(os.environ.get("FTS_SERVER_KEYDIR", Path(fr'{certsPath}/server.key')))
-
-            pemDir = str(os.environ.get("FTS_SERVER_PEMDIR", Path(fr'{certsPath}/server.pem')))  # or crt
-
-            testPem = str(os.environ.get("FTS_TESTCLIENT_PEMDIR", pemDir))
-
-            testKey = str(os.environ.get("FTS_TESTCLIENT_KEYDIR", keyDir))
-
-            unencryptedKey = str(os.environ.get("FTS_UNENCRYPTED_KEYDIR", Path(fr'{certsPath}/server.key.unencrypted')))
-
-            p12Dir = str(os.environ.get("FTS_SERVER_P12DIR", Path(fr'{certsPath}/server.p12')))
-
-            CA = str(os.environ.get("FTS_CADIR", Path(fr'{certsPath}/ca.pem')))
-
-            CAkey = str(os.environ.get("FTS_CAKEYDIR", Path(fr'{certsPath}/ca.key')))
-
-            federationCert = str(os.environ.get("FTS_FEDERATION_CERTDIR", Path(fr'{certsPath}/server.pem')))
-
-            federationKey = str(os.environ.get("FTS_FEDERATION_KEYDIR", Path(fr'{certsPath}/server.key')))
-
-            federationKeyPassword = str(os.environ.get("FTS_FEDERATION_KEYPASS", 'defaultpass'))
-
-            password = str(os.environ.get('FTS_CLIENT_CERT_PASSWORD', 'supersecret'))
-
-            websocketkey = str(os.environ.get('FTS_WEBSOCKET_KEY', "YourWebsocketKey"))
-
-            CRLFile = str(os.environ.get('FTS_CRLDIR', fr"{certsPath}/FTS_CRL.json"))
-
-
+    # Federation port
+    FederationPort = 9000
 
     # allowed ip's to access CLI commands
     AllowedCLIIPs = ['127.0.0.1']
@@ -295,15 +54,155 @@ class MainConfig:
     # IP for CLI to access
     CLIIP = '127.0.0.1'
 
+    ## API Settings ##
     APIVersion = "1.9.5"
+    nodeID = f"FreeTAKServer-{uuid4()}"
+    OptimizeAPI = True
+    DataReceptionBuffer = 1024
+    MaxReceptionTime = 4
 
-    # format of API message header should be {Authentication: Bearer 'TOKEN'}
-    from uuid import uuid4
-    id = str(uuid4())
+    # number of milliseconds to wait between each iteration of main loop
+    # decreasing will increase CPU usage and server performance
+    # increasing will decrease CPU usage and server performance
+    MainLoopDelay = 100
 
-    nodeID = os.environ.get('FTS_NODE_ID', f"FreeTAKServer-{id}")
+    # set to None if you don't want a message sent
+    ConnectionMessage = f'Welcome to FreeTAKServer {version}. The Parrot is not dead. It’s just resting'
 
+    ## Database Settings ##
+    # whether or not to save CoT's to the DB
+    SaveCoTToDB = True
+
+    # this should be set before startup
+    DBFilePath = '/opt/FTSDataBase.db'
+    DataBaseType = 'SQLite'
+
+    ## Paths ##
+    MainPath = Path(fr'{userpath}{python_version}/dist-packages/FreeTAKServer')
+    ExCheckMainPath = Path(fr'{MainPath}/ExCheck')
+    ExCheckFilePath = Path(fr'{MainPath}/ExCheck/template')
+    ExCheckChecklistFilePath = Path(fr'{MainPath}/ExCheck/checklist')
+    DataPackageFilePath = Path(fr'{MainPath}/FreeTAKServerDataPackageFolder')
+    LogFilePath = Path(fr'{MainPath}/Logs')
+    certsPath = Path(fr'{MainPath}/certs')
     # location to backup client packages
     clientPackages = str(Path(fr'{MainPath}/certs/ClientPackages'))
 
-    first_start = True
+    ## Certificate Settings ##
+    keyDir = Path(fr'{certsPath}/server.key')
+    pemDir = Path(fr'{certsPath}/server.pem') # or crt
+    testPem = ''
+    testKey = ''
+    unencryptedKey = Path(fr'certsPath}/server.key.unencrypted')
+    p12Dir = Path(fr'{certsPath}/server.p12')
+    CA = Path(fr'{certsPath}/ca.pem')
+    CAkey = Path(fr'{certsPath}/ca.key')
+    CRLFile = Path(fr"{certsPath}/FTS_CRL.json")
+
+    ## Federation Settings ##
+    federationKeyPassword = 'defaultpass'
+    federationCert = Path(fr'{certsPath}/server.pem')
+    federationKey = Path(fr'{certsPath}/server.key')
+    federationKeyPassword = 'defaultpass'
+
+    ## Secrets ##
+    password = 'supersecret'
+    websocketkey = "YourWebsocketKey"
+    SecretKey = 'vnkdjnfjknfl1232#'
+
+    # Overlay the settings from the YAML config if it exists
+    if os.path.exists(yaml_path):
+        try:
+            yamlConfig = yaml.safe_load(open(yaml_path).read())
+        except OSError as e:
+            raise RuntimeError(f"{yaml_path} exists, but can not be read")
+
+        if yamlConfig.get("System"):
+            MainLoopDelay = int(yamlConfig["System"].get("FTS_MAINLOOP_DELAY", MainLoopDelay))
+            ConnectionMessage = yamlConfig["System"].get("FTS_CONNECTION_MESSAGE", ConnectionMessage)
+            DataBaseType = yamlConfig["System"].get("FTS_DATABASE_TYPE", DataBaseType)
+            OptimizeAPI = bool(yamlConfig["System"].get("FTS_OPTIMIZE_API", OptimizeAPI))
+            SecretKey = yamlConfig["System"].get("FTS_SECRET_KEY", SecretKey)
+            DataReceptionBuffer = int(yamlConfig["System"].get("FTS_DATA_RECEPTION_BUFFER", DataReceptionBuffer))
+            MaxReceptionTime = int(yamlConfig["System"].get("FTS_MAX_RECEPTION_TIME", MaxReceptionTime))
+            nodeID = yamlConfig["System"].get("FTS_NODE_ID", nodeID)
+
+        if yamlConfig.get("Addresses"):
+            CoTServicePort = int(yamlConfig["Addresses"].get('FTS_COT_PORT', CoTServicePort))
+            SSLCoTServicePort = int(yamlConfig["Addresses"].get('FTS_SSLCOT_PORT', SSLCoTServicePort))
+            DataPackageServiceDefaultIP = yamlConfig["Addresses"].get('FTS_DP_ADDRESS', DataPackageServiceDefaultIP)
+            UserConnectionIP = yamlConfig["Addresses"].get("FTS_USER_ADDRESS", UserConnectionIP)
+            APIPort = int(yamlConfig["Addresses"].get("FTS_API_PORT", APIPort))
+            APIIP = yamlConfig["Addresses"].get("FTS_API_ADDRESS", APIIP)
+            FederationPort = int(yamlConfig["Addresses"].get("FTS_FED_PORT", FederationPort))
+            AllowedCLIIPs = yamlConfig["Addresses"].get("FTS_CLI_WHITELIST", AllowedCLIIPs)
+            CLIIP = yamlConfig["Addresses"].get("FTS_CLI_IP", CLIIP)
+
+        if yamlConfig.get("FileSystem"):
+            DBFilePath = yamlConfig["FileSystem"].get("FTS_DB_PATH", DBFilePath)
+            SaveCoTToDB = bool(yamlConfig["FileSystem"].get("FTS_COT_TO_DB", SaveCoTToDB))
+            MainPath = yamlConfig["FileSystem"].get("FTS_MAINPATH", MainPath)
+            certsPath = yamlConfig["FileSystem"].get("FTS_CERTS_PATH", certsPath)
+            ExCheckMainPath = yamlConfig["FileSystem"].get("FTS_EXCHECK_PATH", ExCheckMainPath)
+            ExCheckFilePath = yamlConfig["FileSystem"].get("FTS_EXCHECK_TEMPLATE_PATH", ExCheckFilePath)
+            ExCheckChecklistFilePath = yamlConfig["FileSystem"].get("FTS_EXCHECK_CHECKLIST_PATH", ExCheckChecklistFilePath)
+            DataPackageFilePath = yamlConfig["FileSystem"].get("FTS_DATAPACKAGE_PATH", DataPackageFilePath)
+            LogFilePath = yamlConfig["FileSystem"].get("FTS_LOGFILE_PATH", LogFilePath)
+
+        if yamlConfig.get("Certs"):
+            keyDir = yamlConfig["Certs"].get("FTS_SERVER_KEYDIR", keyDir)
+            pemDir = yamlConfig["Certs"].get("FTS_SERVER_PEMDIR", pemDir)
+            testPem = yamlConfig["Certs"].get("FTS_TESTCLIENT_PEMDIR", testPem)
+            testKey = yamlConfig["Certs"].get("FTS_TESTCLIENT_KEYDIR", testKey)
+            unencryptedKey = yamlConfig["Certs"].get("FTS_UNENCRYPTED_KEYDIR", unencryptedKey)
+            p12Dir = yamlConfig["Certs"].get("FTS_SERVER_P12DIR", p12Dir)
+            CA = yamlConfig["Certs"].get("FTS_CADIR", CA)
+            CAkey = yamlConfig["Certs"].get("FTS_CAKEYDIR", CAkey)
+            federationCert = yamlConfig["Certs"].get("FTS_FEDERATION_CERTDIR", federationCert)
+            federationKey = yamlConfig["Certs"].get("FTS_FEDERATION_KEYDIR", federationKey)
+            federationKeyPassword = yamlConfig["Certs"].get("FTS_FEDERATION_KEYPASS", federationKeyPassword)
+            password = yamlConfig["Certs"].get("FTS_CLIENT_CERT_PASSWORD", password)
+            websocketkey = yamlConfig["Certs"].get("FTS_WEBSOCKET_KEY", websocketkey)
+            CRLFile = yamlConfig["Certs"].get("FTS_CRLDIR", CRLFile)
+
+    # Allow env vars to modify configuration
+    MainLoopDelay = int(os.environ.get('FTS_MAINLOOP_DELAY', MainLoopDelay))
+    ConnectionMessage = os.environ.get("FTS_CONNECTION_MESSAGE", ConnectionMessage)
+    DataBaseType = os.environ.get("FTS_DATABASE_TYPE", DataBaseType)
+    OptimizeAPI = bool(os.environ.get("FTS_OPTIMIZE_API", OptimizeAPI))
+    SecretKey = os.environ.get("FTS_SECRET_KEY", SecretKey)
+    DataReceptionBuffer = int(os.environ.get("FTS_DATA_RECEPTION_BUFFER", DataReceptionBuffer))
+    MaxReceptionTime = int(os.environ.get("FTS_MAX_RECEPTION_TIME", MaxReceptionTime))
+    nodeID = os.environ.get("FTS_NODE_ID", nodeID)
+    CoTServicePort = int(os.environ.get('FTS_COT_PORT', CoTServicePort))
+    SSLCoTServicePort = int(os.environ.get('FTS_SSLCOT_PORT', SSLCoTServicePort))
+    DataPackageServiceDefaultIP = os.environ.get('FTS_DP_ADDRESS', DataPackageServiceDefaultIP)
+    UserConnectionIP = os.environ.get("FTS_USER_ADDRESS", UserConnectionIP)
+    APIPort = int(os.environ.get("FTS_API_PORT", APIPort))
+    APIIP = os.environ.get("FTS_API_ADDRESS", APIIP)
+    FederationPort = int(os.environ.get("FTS_FED_PORT", FederationPort))
+    AllowedCLIIPs = re.split(r'[,:]', os.environ.get("FTS_CLI_WHITELIST")) or AllowedCLIIPs
+    CLIIP = os.environ.get("FTS_CLI_IP", CLIIP)
+    DBFilePath = os.environ.get("FTS_DB_PATH", DBFilePath)
+    SaveCoTToDB = bool(os.environ.get("FTS_COT_TO_DB", SaveCoTToDB))
+    MainPath = os.environ.get("FTS_MAINPATH", MainPath)
+    certsPath = os.environ.get("FTS_CERTS_PATH", certsPath)
+    ExCheckMainPath = os.environ.get("FTS_EXCHECK_PATH", ExCheckMainPath)
+    ExCheckFilePath = os.environ.get("FTS_EXCHECK_TEMPLATE_PATH", ExCheckFilePath)
+    ExCheckChecklistFilePath = os.environ.get("FTS_EXCHECK_CHECKLIST_PATH", ExCheckChecklistFilePath)
+    DataPackageFilePath = os.environ.get("FTS_DATAPACKAGE_PATH", DataPackageFilePath)
+    LogFilePath = os.environ.get("FTS_LOGFILE_PATH", LogFilePath)
+    keyDir = os.environ.get("FTS_SERVER_KEYDIR", keyDir)
+    pemDir = os.environ.get("FTS_SERVER_PEMDIR", pemDir)
+    testPem = os.environ.get("FTS_TESTCLIENT_PEMDIR", testPem)
+    testKey = os.environ.get("FTS_TESTCLIENT_KEYDIR", testKey)
+    unencryptedKey = os.environ.get("FTS_UNENCRYPTED_KEYDIR", unencryptedKey)
+    p12Dir = os.environ.get("FTS_SERVER_P12DIR", p12Dir)
+    CA = os.environ.get("FTS_CADIR", CA)
+    CAkey = os.environ.get("FTS_CAKEYDIR", CAkey)
+    federationCert = os.environ.get("FTS_FEDERATION_CERTDIR", federationCert)
+    federationKey = os.environ.get("FTS_FEDERATION_KEYDIR", federationKey)
+    federationKeyPassword = os.environ.get("FTS_FEDERATION_KEYPASS", federationKeyPassword)
+    password = os.environ.get("FTS_CLIENT_CERT_PASSWORD", password)
+    websocketkey = os.environ.get("FTS_WEBSOCKET_KEY", websocketkey)
+    CRLFile = os.environ.get("FTS_CRLDIR", CRLFile)

--- a/FreeTAKServer/controllers/configuration/MainConfig.py
+++ b/FreeTAKServer/controllers/configuration/MainConfig.py
@@ -94,7 +94,7 @@ class MainConfig:
     pemDir = Path(fr'{certsPath}/server.pem') # or crt
     testPem = ''
     testKey = ''
-    unencryptedKey = Path(fr'certsPath}/server.key.unencrypted')
+    unencryptedKey = Path(fr'{certsPath}/server.key.unencrypted')
     p12Dir = Path(fr'{certsPath}/server.p12')
     CA = Path(fr'{certsPath}/ca.pem')
     CAkey = Path(fr'{certsPath}/ca.key')

--- a/FreeTAKServer/controllers/configuration/MainConfig.py
+++ b/FreeTAKServer/controllers/configuration/MainConfig.py
@@ -1,6 +1,7 @@
 import os
 import yaml
-currentPath = os.path.dirname(os.path.abspath(__file__))
+import random
+from string import ascii_letters, digits, punctuation
 from pathlib import Path
 from uuid import uuid4
 
@@ -100,7 +101,6 @@ class MainConfig:
     CRLFile = Path(fr"{certsPath}/FTS_CRL.json")
 
     ## Federation Settings ##
-    federationKeyPassword = 'defaultpass'
     federationCert = Path(fr'{certsPath}/server.pem')
     federationKey = Path(fr'{certsPath}/server.key')
     federationKeyPassword = 'defaultpass'
@@ -108,7 +108,7 @@ class MainConfig:
     ## Secrets ##
     password = 'supersecret'
     websocketkey = "YourWebsocketKey"
-    SecretKey = 'vnkdjnfjknfl1232#'
+    SecretKey = ''.join(random.choice(ascii_letters + digits + punctuation) for i in range(18))
 
     # Overlay the settings from the YAML config if it exists
     if os.path.exists(yaml_path):


### PR DESCRIPTION
This PR mostly started as a better way to handle the problems seen in #324. 

Looking at `MainConfig.py` it was found that there was little consistency in how the configuration was generated. Some of the things found:

- Variables were getting set to different defaults depending upon what code path was taken
- Most file path variables were utilizing `Path`, but not all
- The complex `if-else` logic allowed some variables not be created in certain conditions (hence #324)

In weeding through the logic it became obvious that a refactor was needed to simplify the structure and provide more reproducible configurations and future proof the code.

Now **all** variables are defined up front with sane defaults. Even if new variables are added the code will not break because an older configuration file is being used. If a YAML configuration file is present, it will be read in and the values will be applied to the in memory configuration without disturbing any variables not referenced in the configuration file. Finally, the in memory configuration is updated by any environment variables defined. 

There are a couple of subtle changes that this PR applies that were not present in the original `MainConfig.py` file. 

1. `nodeID` was not configurable from YAML or env var. Now can be set from `System.FTS_NODE_ID` or `$FTS_NODE_ID`.
2. `CLIIP` also was not configurable. Now can be set from `Addresses.FTS_CLI_IP` or `$FTS_CLI_IP`.
3. , `AllowedCLIIPs` can now be configured from `Addresses.FTS_CLI_WHITELIST` or `$FTS_CLI_WHITELIST`. When being set from `$FTS_CLI_WHITELIST`, the value will be split on colon or comma to produce a list for the variable. 
4. `SecretKey` is now randomly generated upon startup. It can be set in YAML (`System.FTS_SECRET_KEY`) or env var (`$FTS_SECRET_KEY`) if there is a need for having a static value. 