### PR TITLE
Added Python 3.11 to the unittest matrix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This change adds Python 3.11 to the testing job in the pipeline. 

Signed-off-by: Gerard Hickey <hickey@kinetic-compute.com>