### PR TITLE
use pathlib to determine MAINPATH

### DIFF
--- a/FreeTAKServer/core/configuration/MainConfig.py
+++ b/FreeTAKServer/core/configuration/MainConfig.py
@@ -11,11 +11,8 @@ from uuid import uuid4
 
 FTS_VERSION = "FreeTAKServer-2.0.19 Beta"
 API_VERSION = "1.9.6"
-# TODO Need to find a better way to determine python version at runtime
-PYTHON_VERSION = "python3.11"
 ROOTPATH = "/"
-USERPATH = rf"{ROOTPATH}usr/local/lib/"
-MAINPATH = rf"{USERPATH}{PYTHON_VERSION}/dist-packages/FreeTAKServer"
+MAINPATH = Path(__file__).parent.parent.parent
 PERSISTENCE_PATH = r'/opt/fts'
 
 class MainConfig:


### PR DESCRIPTION
use pathlib to determine MAINPATH of module; resolves issues when working with different versions of python or other reasons for having a different module location (like Docker, or Windows).