### PR TITLE
More relaxing timeout to receive connection data

### DIFF
--- a/FreeTAKServer/core/configuration/ReceiveConnectionsConstants.py
+++ b/FreeTAKServer/core/configuration/ReceiveConnectionsConstants.py
@@ -1,6 +1,6 @@
 class ReceiveConnectionsConstants:
     def __init__(self):
-        self.RECEIVECONNECTIONDATATIMEOUT = 4
+        self.RECEIVECONNECTIONDATATIMEOUT = 30
         self.CONNECTION_DATA_BUFFER = 1024
         self.TESTDATA = 'TEST'
         # timeout for the wrap socket operation in seconds


### PR DESCRIPTION
Set `RECEIVECONNECTIONDATATIMEOUT` from 4 to 30.
This is for iTAK clients, where clients are not sending "connection data" just after connection is created.

I've been experiencing the initial connection setup failure because iTAK clients are not sending connection data just after connection is created. This may be iTAK's violation of the protocol, but this causes "listen -> accept" process failure (logs below) on FTS server to communicate with iTAK.

```
client connected over ssl ('192.168.0.33', 49962) 1680342971.287079
receiving connection data from client failed with exception The read operation timed out
```

I found iTAK sends connection data not at once, but "a while later."
"A while later" period likely depends on iTAK's "Location Reporting" settings. The default value of reporting rate (report interval) is at most 60 seconds.

I think it is worth waiting for connection data arrivals, extending `RECEIVECONNECTIONDATATIMEOUT` up to 30 secs (There are two trials to receive the data, so the constant value 30 equals 60 seconds grace). 