### PR TITLE
fix: incorrect branch in wemake workflow

### DIFF
--- a/.github/workflows/wemake.yml
+++ b/.github/workflows/wemake.yml
@@ -2,10 +2,10 @@ name: "wemake_validation"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "master" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ "master" ]
   schedule:
     - cron: '28 18 * * 4'
 


### PR DESCRIPTION
The wemake workflow references the 'main' branch, but FTS uses the 'master' branch.  