### PR TITLE
Configuration File Not Being Read

### DIFF
--- a/FreeTAKServer/core/configuration/MainConfig.py
+++ b/FreeTAKServer/core/configuration/MainConfig.py
@@ -377,7 +377,7 @@ class MainConfig:
 
             # if config_file not specified, check env or use default location
             if config_file == None:
-                config_file = str(os.environ.get('FTS_CONFIG_PATH', MainConfig._defaults["yaml_path"]))
+                config_file = str(os.environ.get('FTS_CONFIG_PATH', MainConfig._defaults["yaml_path"]["default"]))
 
             # overlay the yaml config if found
             if os.path.exists(config_file):


### PR DESCRIPTION
This PR should fix FTS failing to read the FTSconfig.yaml configuration file. Explanation located in issue [625](https://github.com/FreeTAKTeam/FreeTakServer/issues/625).