### PR TITLE
661 emergencies not shared

### DIFF
--- a/FreeTAKServer/components/extended/emergency/configuration/external_action_mapping.ini
+++ b/FreeTAKServer/components/extended/emergency/configuration/external_action_mapping.ini
@@ -1,15 +1,15 @@
 [actionmapping]
-?emergency?EmergencyAlert = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.create_emergency_alert
-?emergency?EmergencyInContact = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.create_emergency_alert
-?emergency?EmergencyRingTheBell = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.create_emergency_alert
-?emergency?EmergencyGeoFenceBreached = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.create_emergency_alert
+??EmergencyAlert = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.create_emergency_alert
+??EmergencyInContact = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.create_emergency_alert
+??EmergencyRingTheBell = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.create_emergency_alert
+??EmergencyGeoFenceBreached = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.create_emergency_alert
 
-?emergency?EmergencyCancelled = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.cancel_emergency_alert
+??EmergencyCancelled = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.cancel_emergency_alert
 
-?emergency?BroadcastEmergency = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.broadcast_emergency
-?emergency?SendEmergenciesToClient = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.send_emergencies_to_client
+??BroadcastEmergency = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.broadcast_emergency
+??SendEmergenciesToClient = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.send_emergencies_to_client
 
-?emergency?GetAllEmergencies = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.get_all_emergencies
+??GetAllEmergencies = FreeTAKServer.components.extended.emergency.emergency_facade.Emergency.get_all_emergencies
 
 [servicemapping]
 ??EmergencyAlert = [TCPCoTService, ssl_cot_service]

--- a/FreeTAKServer/components/extended/emergency/controllers/emergency_general_controller.py
+++ b/FreeTAKServer/components/extended/emergency/controllers/emergency_general_controller.py
@@ -75,10 +75,13 @@ class EmergencyGeneralController(Controller):
 
         # check that the distance between the user and the emergency is less than 10km
         # TODO: this hardcoded distance should be added to the business rules
-        return (
-            distance.geodesic(
-                (connection_location.lat, connection_location.lon),
-                (emergency.point.lat, emergency.point.lon),
-            ).km
-            < config.EmergencyRadius
-        )
+        if config.EmergencyRadius==0:
+            return True
+        else:
+            return (
+                distance.geodesic(
+                    (connection_location.lat, connection_location.lon),
+                    (emergency.point.lat, emergency.point.lon),
+                ).km
+                < config.EmergencyRadius
+            )


### PR DESCRIPTION
# Pull Request: Fix for Issue #661

## Changes Made

- Removed context from the emergency component action mapping.
- Added an if condition to distance validation to ensure emergencies are sent to all clients if the distance is set to 0.

## Context

This pull request addresses the specific issue with emergency handling identified in issue #661. The removal of context from the emergency component action mapping and the addition of a necessary condition in distance validation enhance the reliability of emergency communication across all clients.

## Related Issue

- Fixed issue #661.