### PR TITLE
Bump PyYAML 6.0 -> 6.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "pykml==0.2.0",
         "python-engineio==3.13.2",
         "python-socketio==4.6.0",
-        "PyYAML==6.0",
+        "PyYAML==6.0.1",
         "ruamel.yaml==0.17.21",
         "ruamel.yaml.clib==0.2.7",
         "six==1.16.0",


### PR DESCRIPTION
pip install fails on PyYAML==6.0
See for yourself with the following dockerfile:
```
from fedora
run dnf install python3-pip -y
run pip install PyYAML==6.0
```