### PR TITLE
Feature/container volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,28 +20,6 @@ ENV PATH /home/freetak/.local/bin:$PATH
 RUN pip install --upgrade pip ; pip install setuptools wheel poetry ; pip install --force-reinstall "ruamel.yaml<0.18"
 RUN pip install --no-build-isolation --editable .
 
-# Provide a way to edit the configuration from outside the container
-# May need to be updated if the base image changes
-RUN cp FreeTAKServer/core/configuration/MainConfig.py FreeTAKServer/core/configuration/MainConfig.bak
-RUN mv FreeTAKServer/core/configuration/MainConfig.py /opt/fts/MainConfig.py
-RUN ln -s /opt/fts/MainConfig.py FreeTAKServer/core/configuration/MainConfig.py
-
-# Open ports
-# note: docker compose documentation suggests that communication between
-#       core and ui doesn't need a port explicitly exposed
-# DataPackagePort
-EXPOSE 8080
-# CoTPort
-EXPOSE 8087
-# SSLCoTPort
-EXPOSE 8089
-# SSLDataPackagePort
-EXPOSE 8443
-# FederationPort
-EXPOSE 9000
-# APIPort - Don't expose by default
-#EXPOSE 19023
-
 VOLUME /opt/fts
 
 CMD [ "/home/freetak/docker-run.sh" ]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,56 @@
+services:
+  fts:
+    image: freetakserver:latest
+    pull_policy: build
+    restart: unless-stopped
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./base-config/:/opt/fts/:rw,Z
+    network_mode: "host"
+    environment:
+        # The ChangeMe section
+        FTS_FED_PASSWORD: "defaultpass"
+        FTS_CLIENT_CERT_PASSWORD: "password"
+        FTS_SECRET_KEY: "vnkdjnfjknfl1232#"
+        FTS_NODE_ID: "fl5m8j5txlgdtfv8wi96zf8tt0howddo"
+        FTS_CONNECTION_MESSAGE: "Welcome to FreeTAKServer. The Parrot is not dead. It’s just resting"
+
+        # Networking
+        FTS_COT_PORT: 8087
+        FTS_SSLCOT_PORT: 8089
+        FTS_API_PORT: 19023
+        FTS_FED_PORT: 9000
+
+        FTS_DP_ADDRESS: 127.0.0.1
+        FTS_USER_ADDRESS: 127.0.0.1
+        FTS_API_ADDRESS: 0.0.0.0
+
+        FTS_ROUTING_PROXY_SUBSCRIBE_PORT: 19030
+        FTS_ROUTING_PROXY_SUBSCRIBE_IP: 127.0.0.1
+
+        FTS_ROUTING_PROXY_PUBLISHER_PORT: 19032
+        FTS_ROUTING_PROXY_PUBLISHER_IP: 127.0.0.1
+
+        FTS_ROUTING_PROXY_SERVER_PORT: 19031
+        FTS_ROUTING_PROXY_SERVER_IP: 127.0.0.1
+
+        FTS_INTEGRATION_MANAGER_PULLER_PORT: 19033 # port to receive worker responses by the integration manager
+        FTS_INTEGRATION_MANAGER_PULLER_ADDRESS: 127.0.0.1 # address to receive worker responses by the integration manager
+
+        FTS_INTEGRATION_MANAGER_PUBLISHER_PORT: 19034 # port from which to publish messages by the integration manager
+        FTS_INTEGRATION_MANAGER_PUBLISHER_ADDRESS: 127.0.0.1 # address from which to publish messages by the integration manager
+
+        # Misc Settings
+        FTS_OPTIMIZE_API: True
+        FTS_DATA_RECEPTION_BUFFER: 1024
+        FTS_MAX_RECEPTION_TIME: 4
+        FTS_NUM_ROUTING_WORKERS: 3
+        FTS_COT_TO_DB: True
+        # number of milliseconds to wait between each iteration of main loop
+        # decreasing will increase CPU usage and server performance
+        # increasing will decrease CPU usage and server performance
+        FTS_MAINLOOP_DELAY: 100
+        FTS_EMERGENCY_RADIUS: 0 # radius of emergency within-which users will receive it
+        FTS_LOG_LEVEL: "info"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,5 @@
 services:
-  fts:
+  freetakserver:
     image: freetakserver:latest
     pull_policy: build
     restart: unless-stopped
@@ -7,8 +7,21 @@ services:
       context: .
       dockerfile: Dockerfile
     volumes:
-      - ./base-config/:/opt/fts/:rw,Z
-    network_mode: "host"
+      - free-tak-core-db:/opt/fts/
+    ports:
+      # DataPackagePort
+      - 8080:8080
+      # CoTPort
+      - 8087:8087
+      # SSLCoTPort
+      - 8089:8089
+      # SSLDataPackagePort
+      - 8443:8443
+      # FederationPort
+      #- 9000:9000
+      # APIPort - Don't expose by default
+      #- 19023:19023
+
     environment:
         # The ChangeMe section
         FTS_FED_PASSWORD: "defaultpass"
@@ -54,3 +67,6 @@ services:
         FTS_MAINLOOP_DELAY: 100
         FTS_EMERGENCY_RADIUS: 0 # radius of emergency within-which users will receive it
         FTS_LOG_LEVEL: "info"
+
+volumes:
+  free-tak-core-db:

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 
-# Sharing for MainConfig.py
-if [[ ! -f "/opt/fts/MainConfig.py" ]]
-  then
-    cp FreeTAKServer/core/configuration/MainConfig.bak /opt/fts/MainConfig.py
-fi
-if [[ ! -f "FreeTAKServer/core/configuration/MainConfig.py" ]]
-  then
-    ln -s /opt/fts/MainConfig.py FreeTAKServer/core/configuration/MainConfig.py
-fi
-
 # Sharing for FTSConfig.yaml
 if [[ ! -f "/opt/fts/FTSConfig.yaml" ]]
   then


### PR DESCRIPTION
## BLUF

Changes bind-mounts to the newer volumes since bind-mounts are confusing, hard, and are harming user experience.

## Why

Bind mounts are confusing to users, and can sometimes have strange permissions. Additionally, they are not compatible with many docker desktop offerings, in particular docker desktop for windows. Many users are additionally not familiar with UIDs and thus cannot effectively set permissions properly to make the system work. This can leave them more vulnerable to attacks when running on shared systems if the permissions they end up on are too permissive.

Simplifying the persistent storage for the containers seems appropriate given the challenges encountered by users.

## How

Since configuration of the server was already accessible by environment variable, I created a list of the ones I felt were most important and added them to the compose file. Use of all environment variables is of course possible, but many of them probably don't need to be exposed except for highly skilled users in strange use cases.


## Other notes

This will need to be replicated to the FreeTAKHub-Installation repo
Documentation will need to be updated/added in FreeTAKServer-User-Docs