### PR TITLE
701 migrate to testpypiorg

### DIFF
--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -17,7 +17,8 @@ jobs:
     name: upload release to PyPI
     runs-on: ubuntu-latest
     # Specifying a GitHub environment is optional, but strongly encouraged
-    environment: dev
+    environment: 
+      name: dev
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -13,37 +13,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish:
-    name: upload release to PyPI
-    runs-on: ubuntu-latest
-    # Specifying a GitHub environment is optional, but strongly encouraged
-    environment: 
-      name: dev
-    permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
-      id-token: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.sha }}
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.11'
-      # retrieve your distributions here
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install build setuptools poetry
-      - name: Build
-        run: poetry build
-
-      - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
-
   deploy:
     runs-on: ubuntu-latest
 
@@ -54,6 +23,19 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build setuptools poetry
+    - name: Build and publish
+      continue-on-error: true
+      env:
+        POETRY_REPOSITORIES_DEV_URL: http://test.pypi.org/legacy
+        POETRY_HTTP_BASIC_DEV_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        POETRY_HTTP_BASIC_DEV_PASSWORD: ${{ secrets.TEST_PYPI_KEY }}
+      run: |
+        poetry build
+        poetry publish --repository dev
     - name: Clone GuillaumeFalourd/poc-github-actions PUBLIC repository
       uses: GuillaumeFalourd/clone-github-repo-action@v2
       with:

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -13,6 +13,22 @@ on:
   workflow_dispatch:
 
 jobs:
+  publish:
+    name: upload release to PyPI
+    runs-on: ubuntu-latest
+    # Specifying a GitHub environment is optional, but strongly encouraged
+    environment: dev
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      # retrieve your distributions here
+
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
   deploy:
     runs-on: ubuntu-latest
 
@@ -23,19 +39,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.11'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build setuptools poetry
-    - name: Build and publish
-      continue-on-error: true
-      env:
-        POETRY_REPOSITORIES_DEV_URL: http://${{ secrets.DEV_PYPI_ADDRESS }}:8080
-        POETRY_HTTP_BASIC_DEV_USERNAME: ${{ secrets.DEV_PYPI_USERNAME }}
-        POETRY_HTTP_BASIC_DEV_PASSWORD: ${{ secrets.DEV_PYPI_PASSWORD }}
-      run: |
-        poetry build
-        poetry publish --repository dev
     - name: Clone GuillaumeFalourd/poc-github-actions PUBLIC repository
       uses: GuillaumeFalourd/clone-github-repo-action@v2
       with:

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
+        ref: $GITHUB_SHA
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -23,7 +23,19 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
       # retrieve your distributions here
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build setuptools poetry
+      - name: Build
+        run: poetry build
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -33,6 +33,7 @@ jobs:
         poetry build
         poetry config repositories.test-pypi https://test.pypi.org/legacy/
         poetry config pypi-token.test-pypi ${{secrets.TEST_PYPI_KEY}}
+        poetry publish -r test-pypi
     - name: Clone GuillaumeFalourd/poc-github-actions PUBLIC repository
       uses: GuillaumeFalourd/clone-github-repo-action@v2
       with:

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Build and publish
       continue-on-error: true
       env:
-        POETRY_REPOSITORIES_DEV_URL: http://test.pypi.org/legacy
+        POETRY_REPOSITORIES_DEV_URL: http://test.pypi.org/legacy/
         POETRY_HTTP_BASIC_DEV_USERNAME: ${{ secrets.PYPI_USERNAME }}
         POETRY_HTTP_BASIC_DEV_PASSWORD: ${{ secrets.TEST_PYPI_KEY }}
       run: |

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         poetry build
         poetry config repositories.test-pypi https://test.pypi.org/legacy/
-        poetry config pypi-token.test-pypi ${{TEST_PYPI_KEY}}
+        poetry config pypi-token.test-pypi ${{secrets.TEST_PYPI_KEY}}
     - name: Clone GuillaumeFalourd/poc-github-actions PUBLIC repository
       uses: GuillaumeFalourd/clone-github-repo-action@v2
       with:

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -31,7 +31,7 @@ jobs:
       continue-on-error: true
       env:
         POETRY_REPOSITORIES_DEV_URL: http://test.pypi.org/legacy/
-        POETRY_HTTP_BASIC_DEV_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        POETRY_HTTP_BASIC_DEV_USERNAME: __token__
         POETRY_HTTP_BASIC_DEV_PASSWORD: ${{ secrets.TEST_PYPI_KEY }}
       run: |
         poetry build

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -29,13 +29,10 @@ jobs:
         pip install build setuptools poetry
     - name: Build and publish
       continue-on-error: true
-      env:
-        POETRY_REPOSITORIES_DEV_URL: http://test.pypi.org/legacy/
-        POETRY_HTTP_BASIC_DEV_USERNAME: __token__
-        POETRY_HTTP_BASIC_DEV_PASSWORD: ${{ secrets.TEST_PYPI_KEY }}
       run: |
         poetry build
-        poetry publish --repository dev
+        poetry config repositories.test-pypi https://test.pypi.org/legacy/
+        poetry config pypi-token.test-pypi ${{TEST_PYPI_KEY}}
     - name: Clone GuillaumeFalourd/poc-github-actions PUBLIC repository
       uses: GuillaumeFalourd/clone-github-repo-action@v2
       with:

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -25,7 +25,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v2
-        ref: $GITHUB_SHA
+        with:
+          ref: $GITHUB_SHA
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
-          ref: ${GITHUB_SHA}
+          ref: ${{ github.sha }}
       - name: Set up Python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/python-dev-publish.yml
+++ b/.github/workflows/python-dev-publish.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v2
         with:
-          ref: $GITHUB_SHA
+          ref: ${GITHUB_SHA}
       - name: Set up Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Updated github action to publish to test.pypi.org removing the need for a hosted private pypi server