### PR TITLE
include the FTS discord in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ To discuss with the developer team:
 
 - Visit the ATAK subreddit
   <https://www.reddit.com/r/ATAK/>
-- or join the Discord chat
+- or join the ATAK Discord
   <https://discordapp.com/invite/XEPyhHA>
+- or join the FreeTakServer Discord
+  <https://discord.gg/VSukyY5wfD>
 
 ## Architecture
 


### PR DESCRIPTION
The readme does not include the FreeTakServer discord; instead only includes the ATAK discord.

Added the FTS discord too.

source:
![image](https://github.com/FreeTAKTeam/FreeTakServer/assets/40326736/31da5871-cc87-4cbb-a01d-978733c06c17)
