### PR TITLE
configuration: Ensure PERSISTENCE_PATH is correctly set

### DIFF
--- a/FreeTAKServer/core/configuration/MainConfig.py
+++ b/FreeTAKServer/core/configuration/MainConfig.py
@@ -16,7 +16,7 @@ API_VERSION = "3"
 ROOTPATH = "/"
 MAINPATH = Path(__file__).parent.parent.parent
 USERPATH = rf"{ROOTPATH}usr/local/lib/"
-PERSISTENCE_PATH = r'/opt/fts'
+PERSISTENCE_PATH = os.environ.get('FTS_PERSISTENCE_PATH', r'/opt/fts')
 
 class MainConfig:
     """
@@ -59,7 +59,7 @@ class MainConfig:
         "MaxReceptionTime": {"default": 4, "type": int},
         "LogLevel": {"default": "info", "type": str},
         "UserPersistencePath": {
-            "default": Path("/opt/user_persistence.txt"),
+            "default": Path(f"{PERSISTENCE_PATH}/user_persistence.txt"),
             "type": str,
         },
         # number of milliseconds to wait between each iteration of main loop


### PR DESCRIPTION
Using the ``FTS_PERSISTENCE_PATH`` env var doesn't have any effect. This PR fixes it so the env var is picked up early enough in the fts startup