### PR TITLE
Logging fixes

### DIFF
--- a/FreeTAKServer/components/core/domain/configuration/logging.conf
+++ b/FreeTAKServer/components/core/domain/configuration/logging.conf
@@ -8,11 +8,11 @@ keys=stream_handler,fileHandler
 keys=formatter
 
 [logger_root]
-level=DEBUG
+level=ERROR
 handlers=fileHandler
 
 [logger_domain]
-level=DEBUG
+level=ERROR
 qualname=domain
 handlers=fileHandler
 
@@ -24,7 +24,7 @@ args=(sys.stderr,)
 
 [handler_fileHandler]
 class=FileHandler
-level=DEBUG
+level=ERROR
 formatter=formatter
 args=('%(logfilename)s',)
 

--- a/FreeTAKServer/components/core/type/configuration/logging.conf
+++ b/FreeTAKServer/components/core/type/configuration/logging.conf
@@ -8,11 +8,11 @@ keys=stream_handler,fileHandler
 keys=formatter
 
 [logger_root]
-level=DEBUG
+level=ERROR
 handlers=fileHandler
 
 [logger_type]
-level=DEBUG
+level=ERROR
 qualname=type
 handlers=fileHandler
 
@@ -25,7 +25,7 @@ args=(sys.stderr,)
 
 [handler_fileHandler]
 class=FileHandler
-level=DEBUG
+level=ERROR
 formatter=formatter
 args=('%(logfilename)s',)
 

--- a/FreeTAKServer/components/core/xml_serializer/configuration/logging.conf
+++ b/FreeTAKServer/components/core/xml_serializer/configuration/logging.conf
@@ -8,11 +8,11 @@ keys=stream_handler,fileHandler
 keys=formatter
 
 [logger_root]
-level=DEBUG
+level=ERROR
 handlers=fileHandler
 
 [logger_xml_serializer]
-level=DEBUG
+level=ERROR
 qualname=xml_serializer
 handlers=fileHandler
 
@@ -24,7 +24,7 @@ args=(sys.stderr,)
 
 [handler_fileHandler]
 class=FileHandler
-level=DEBUG
+level=ERROR
 formatter=formatter
 args=('%(logfilename)s',)
 

--- a/FreeTAKServer/components/extended/emergency/configuration/logging.conf
+++ b/FreeTAKServer/components/extended/emergency/configuration/logging.conf
@@ -8,11 +8,11 @@ keys=stream_handler,fileHandler
 keys=formatter
 
 [logger_root]
-level=DEBUG
+level=ERROR
 handlers=fileHandler
 
 [logger_emergency]
-level=DEBUG
+level=ERROR
 qualname=emergency
 handlers=fileHandler
 
@@ -24,7 +24,7 @@ args=(sys.stderr,)
 
 [handler_fileHandler]
 class=FileHandler
-level=DEBUG
+level=ERROR
 formatter=formatter
 args=('%(logfilename)s',)
 

--- a/FreeTAKServer/components/extended/excheck/configuration/logging.conf
+++ b/FreeTAKServer/components/extended/excheck/configuration/logging.conf
@@ -8,11 +8,11 @@ keys=stream_handler,fileHandler
 keys=formatter
 
 [logger_root]
-level=DEBUG
+level=ERROR
 handlers=fileHandler
 
 [logger_excheck]
-level=DEBUG
+level=ERROR
 qualname=excheck
 handlers=fileHandler
 
@@ -24,7 +24,7 @@ args=(sys.stderr,)
 
 [handler_fileHandler]
 class=FileHandler
-level=DEBUG
+level=ERROR
 formatter=formatter
 args=('%(logfilename)s',)
 

--- a/FreeTAKServer/components/extended/mission/configuration/logging.conf
+++ b/FreeTAKServer/components/extended/mission/configuration/logging.conf
@@ -8,11 +8,11 @@ keys=stream_handler,fileHandler
 keys=formatter
 
 [logger_root]
-level=DEBUG
+level=ERROR
 handlers=fileHandler
 
 [logger_mission]
-level=DEBUG
+level=ERROR
 qualname=mission
 handlers=fileHandler
 
@@ -24,7 +24,7 @@ args=(sys.stderr,)
 
 [handler_fileHandler]
 class=FileHandler
-level=DEBUG
+level=ERROR
 formatter=formatter
 args=('%(logfilename)s',)
 

--- a/FreeTAKServer/core/configuration/CreateStartupFilesController.py
+++ b/FreeTAKServer/core/configuration/CreateStartupFilesController.py
@@ -9,7 +9,7 @@ class CreateStartupFilesController:
     def __init__(self):
         self.file_dir = os.path.dirname(os.path.realpath(__file__))
         self.dp_directory = PurePath(self.file_dir, DataPackageServerConstants().DATAPACKAGEFOLDER)
-        self.logs_directory = PurePath(LoggingConstants().PARENTPATH)
+        self.logs_directory = PurePath(config.LogFilePath)
         self.client_package = config.ClientPackages
         self.createFolder()
 

--- a/FreeTAKServer/core/configuration/LoggingConstants.py
+++ b/FreeTAKServer/core/configuration/LoggingConstants.py
@@ -1,29 +1,22 @@
 import os
 from pathlib import PurePath, Path
+from FreeTAKServer.core.configuration.MainConfig import MainConfig
+config = MainConfig.instance()
+
 class LoggingConstants:
     def __init__(self, log_name = "FTS"):
         #main logging config
-        # if on a unix type system with /var/log put the logs there
-        if os.path.isdir('/var/log') and os.access('/var/log', os.W_OK):
-            self.PARENTPATH = '/var'
-            self.LOGDIRECTORY = 'log'
-        else:
-            # determine the log path the old way under the execution path
-            self.CURRENTPATH = os.path.dirname(os.path.realpath(__file__))
-            self.CURRENTPATH = PurePath(self.CURRENTPATH)
-            self.PARENTPATH = str(self.CURRENTPATH.parents[0])
-            self.LOGDIRECTORY = 'logs'
 
-            # ensure directory exists
-            Path(PurePath(self.PARENTPATH, self.LOGDIRECTORY)).mkdir(parents=True, exist_ok=True)
+        # ensure directory exists
+        Path(PurePath(config.LogFilePath)).mkdir(parents=True, exist_ok=True)
 
         self.LOGFORMAT = '%(levelname)s : %(asctime)s : %(filename)s:%(lineno)d : %(message)s'
         self.LOGNAME = log_name
 
-        self.ERRORLOG = str(PurePath(self.PARENTPATH, f"{self.LOGDIRECTORY}/{self.LOGNAME}_error.log"))
-        self.DEBUGLOG = str(PurePath(self.PARENTPATH, f"{self.LOGDIRECTORY}/{self.LOGNAME}_debug.log"))
-        self.INFOLOG = str(PurePath(self.PARENTPATH, f"{self.LOGDIRECTORY}/{self.LOGNAME}_info.log"))
-        self.HTTPLOG = str(PurePath(self.PARENTPATH, f"{self.LOGDIRECTORY}/{self.LOGNAME}_http.log"))
+        self.ERRORLOG = str(PurePath(f"{config.LogFilePath}/{self.LOGNAME}_error.log"))
+        self.DEBUGLOG = str(PurePath(f"{config.LogFilePath}/{self.LOGNAME}_debug.log"))
+        self.INFOLOG = str(PurePath(f"{config.LogFilePath}/{self.LOGNAME}_info.log"))
+        self.HTTPLOG = str(PurePath(f"{config.LogFilePath}/{self.LOGNAME}_http.log"))
         self.DELIMITER = ' ? '
         self.MAXFILESIZE = 100000000
         self.BACKUPCOUNT = 5

--- a/FreeTAKServer/core/configuration/MainConfig.py
+++ b/FreeTAKServer/core/configuration/MainConfig.py
@@ -436,7 +436,8 @@ class MainConfig:
         sanitized_path = ROOTPATH + os.path.relpath(os.path.normpath(os.path.join(os.sep, path)), os.sep)
 
         if not os.access(sanitized_path, os.F_OK) or not os.access(sanitized_path, os.W_OK):
-            raise ValueError
+            print(f"Cannot access configuration path: {sanitized_path}")
+            sys.exit(1)
 
         return sanitized_path
 

--- a/FreeTAKServer/core/configuration/configuration_wizard.py
+++ b/FreeTAKServer/core/configuration/configuration_wizard.py
@@ -85,7 +85,7 @@ def ask_user_for_config():
         else:
             print('invalid database type')
     config.DBFilePath = database_path
-    add_to_config(data=database_path, path=["FileSystem", "FTS_DB_PATH"], source=yaml_config)
+    add_to_config(data=database_path, path=["Filesystem", "FTS_DB_PATH"], source=yaml_config)
 
     main_path = get_user_input(question="enter the preferred main path", default=config.MainPath)
     while not valid_and_safe_path(main_path):
@@ -93,14 +93,14 @@ def ask_user_for_config():
         main_path = get_user_input(question="enter the preferred main path", default=config.MainPath)
 
     config.MainPath = main_path
-    add_to_config(path=["FileSystem", "FTS_MAINPATH"], data= main_path, source= yaml_config)
+    add_to_config(path=["Filesystem", "FTS_MAINPATH"], data= main_path, source= yaml_config)
 
     log_path = get_user_input(question="enter the preferred log file path", default=config.LogFilePath)
     while not valid_and_safe_path(log_path):
         print("Invalid path. Path does not exist or insufficient permissions exist.")
         log_path = get_user_input(question="enter the preferred log file path", default=config.LogFilePath)
 
-    add_to_config(path=["FileSystem", "FTS_LOGFILE_PATH"], data=log_path, source=yaml_config)
+    add_to_config(path=["Filesystem", "FTS_LOGFILE_PATH"], data=log_path, source=yaml_config)
 
     add_to_config(path=["System", "FTS_NODE_ID"], data=config.nodeID, source=yaml_config)
 
@@ -156,9 +156,9 @@ def autogenerate_config():
 
     add_to_config(data=config.UserConnectionIP, path=["Addresses", "FTS_DP_ADDRESS"], source=yaml_config)
     add_to_config(data=config.UserConnectionIP, path=["Addresses", "FTS_USER_ADDRESS"], source=yaml_config)
-    add_to_config(data=config.DBFilePath, path=["FileSystem", "FTS_DB_PATH"], source=yaml_config)
-    add_to_config(path=["FileSystem", "FTS_MAINPATH"], data=config.MainPath, source=yaml_config)
-    add_to_config(path=["FileSystem", "FTS_LOGFILE_PATH"], data=config.LogFilePath, source=yaml_config)
+    add_to_config(data=config.DBFilePath, path=["Filesystem", "FTS_DB_PATH"], source=yaml_config)
+    add_to_config(path=["Filesystem", "FTS_MAINPATH"], data=config.MainPath, source=yaml_config)
+    add_to_config(path=["Filesystem", "FTS_LOGFILE_PATH"], data=config.LogFilePath, source=yaml_config)
     add_to_config(path=["System", "FTS_NODE_ID"], data=config.nodeID, source=yaml_config)
 
     file = open(config.yaml_path, mode="w+")
@@ -185,7 +185,7 @@ Addresses:
   #FTS_API_PORT: 19023
   #FTS_FED_PORT: 9000
   #FTS_API_ADDRESS: 0.0.0.0
-FileSystem:
+Filesystem:
   FTS_DB_PATH: /opt/fts/FreeTAKServer.db
   #FTS_COT_TO_DB: True
   FTS_PERSISTENCE_PATH: /opt/fts/

--- a/FreeTAKServer/core/cot_management/configuration/logging.conf
+++ b/FreeTAKServer/core/cot_management/configuration/logging.conf
@@ -8,11 +8,11 @@ keys=stream_handler,fileHandler
 keys=formatter
 
 [logger_root]
-level=DEBUG
+level=ERROR
 handlers=fileHandler
 
 [logger_cotmanagement]
-level=DEBUG
+level=ERROR
 qualname=cotmanagement
 handlers=fileHandler
 
@@ -24,7 +24,7 @@ args=(sys.stderr,)
 
 [handler_fileHandler]
 class=FileHandler
-level=DEBUG
+level=ERROR
 formatter=formatter
 args=('%(logfilename)s',)
 

--- a/FreeTAKServer/core/enterprise_sync/configuration/logging.conf
+++ b/FreeTAKServer/core/enterprise_sync/configuration/logging.conf
@@ -8,11 +8,11 @@ keys=stream_handler,fileHandler
 keys=formatter
 
 [logger_root]
-level=DEBUG
+level=ERROR
 handlers=fileHandler
 
 [logger_enterprisesync]
-level=DEBUG
+level=ERROR
 qualname=enterprisesync
 handlers=fileHandler
 
@@ -24,7 +24,7 @@ args=(sys.stderr,)
 
 [handler_fileHandler]
 class=FileHandler
-level=DEBUG
+level=ERROR
 formatter=formatter
 args=('%(logfilename)s',)
 


### PR DESCRIPTION
A few things in here whilst I was trying to sort out logging:
1. There was some inconsistencies between ``Filesystem`` and ``FileSystem`` naming in the FTSConfig.yaml which led to the File system setings being ignored - as yaml is case sensitive
2. I found that some logs were being saved to different folders. I made it more consistent by pointing all logs to ``FTS_LOGFILE_PATH``
3. Changed the default log level for DigitalPy to error, to (significantly) reduce the logfile size.